### PR TITLE
room-sharing page complete & also in the dropdown

### DIFF
--- a/src/_includes/nav.html
+++ b/src/_includes/nav.html
@@ -21,7 +21,21 @@
     </ul>
   </li>
   <li><a href="/schedule/">Schedule</a></li>
-  <li><a href="/venue/">Venue</a></li>
+  <li><a href="/venue/"
+    data-menu-trigger
+    aria-haspopup="true"
+    aria-expanded="false">Venue</a>
+    <ul
+      data-menu-list
+      role="menu"
+      class="hidden site-nav-menu">
+      <li><a href="/venue/#welcome">Welcome to Durham!</a></li>
+      <li><a href="/venue/#hotel">Staying in Durham</a></li>
+      <li><a href="/venue/#places">Around Durham</a></li>
+      <li><a href="/venue/#accessibility">Accessibility</a></li>
+      <li><a href="/room-sharing/" role="menuitem">Room Sharing</a></li>
+    </ul>
+  </li>
   <li>
     <a href="/speaking/"
       data-menu-trigger

--- a/src/room-sharing.html
+++ b/src/room-sharing.html
@@ -1,0 +1,47 @@
+---
+layout: default
+
+title: Room Sharing
+description: Share a room or ride
+---
+
+<div class="block-container">
+  <div class="wrapper">
+    <header class="flex flex-wrap items-center">
+      <div class="flex-1 max-w-screen-lg">
+        <h1 class="mb-12 pageheading">{{ title }}</h1>
+      </div>
+    </header>
+  </div>
+</div>
+
+<div class="bg-gray-100 block-container">
+  <div class="wrapper">
+    <div class="prose lg:prose-lg">
+
+
+      <p>Do you want to share a room at <a href="/venue/#hotel">one of the hotels</a> with other attendees, or do you have local accommodation available? Do you want to drive to DjangoCon US from Charlotte, Greensboro, Raleigh, or other relatively nearby cities?</p>
+
+      <p>We have a <a href="https://docs.google.com/spreadsheets/d/1487pyAR--sN3dpSDrDQWAQmxq25BgHIVM99xZIHRpp4/edit?usp=sharing">Google sheet</a> just for you! There are tabs for people who already have room reservations and are looking for roommates, who haven't yet booked anything, who live locally and want to offer their homes as accommodation, and who will be driving to Durham and need car buddies.</p>
+      <p>If you're looking for a room, list your contact information along with:</p>
+
+      <ul>
+      <li>How many other people you want to share with</li>
+      <li>What nights you'll be there</li>
+      <li>Wheather you've already reserved a room</li>
+      <li>Any other requirements (e.g. man/woman, smoking/non, snoring/non, etc.)</li>
+      </ul>
+      <p>If you’re looking for or offering a ride, list your contact information along with the dates you’re travelling and where you’re coming from.</p>
+
+      <p><b>Note:</b> If any of your roommates will be arriving separately, be sure to list their names on the reservation as having permission to check in and get a key to your shared room from the front desk by showing photo ID.</p>
+
+      <p>When reserving your room, be sure to specify the type and number of beds. Some rooms only have a single king size bed.</p>
+
+      <p><b>Caution:</b> Room and ride sharing arrangements are the responsibilities of the individual parties involved. DEFNA, DSF, and DjangoCon US staff take no responsibility, and cannot be involved in any disputes.</p>
+
+      <a class="button text-gray-500" href="https://docs.google.com/spreadsheets/d/1487pyAR--sN3dpSDrDQWAQmxq25BgHIVM99xZIHRpp4/edit?usp=sharing">Share a Room or Ride (spreadsheet information)</a>
+
+    </div>
+  </div>
+</div>
+

--- a/src/venue.html
+++ b/src/venue.html
@@ -27,7 +27,7 @@ other_lodging:
 <div class="block-container">
   <div class="wrapper">
     <div class="grid-1-2">
-      <section>
+      <section id="welcome">
         <h1 class="mb-4 pageheading">Welcome to Durham!</h1>
         <div class="space-y-6 text-xl lg:text-2xl">
           <p>
@@ -72,7 +72,7 @@ other_lodging:
   </div>
 </div>
 
-<div class="block-container bg-gray-50" id="welcome">
+<div class="block-container bg-gray-50" id="hotel">
   <div class="wrapper">
     <div class="grid-1-2">
       <figure>
@@ -164,7 +164,7 @@ other_lodging:
 <div class="block-container">
   <div class="wrapper">
     <header class="mb-12">
-      <h2 class="mb-6 text-3xl font-bold font-heading lg:text-5xl">Around Durham</h2>
+      <h2 class="mb-6 text-3xl font-bold font-heading lg:text-5xl" id="places">Around Durham</h2>
       <p class="space-y-6 text-xl lg:text-2xl max-w-[60rem]">
         Public transportation is available via the
         <a href="https://gotriangle.org/maps-schedules/gotriangle" class="link">GoTriangle</a>
@@ -201,7 +201,7 @@ other_lodging:
 
 <div class="block-container">
   <div class="wrapper">
-    <header class="mb-12">
+    <header class="mb-12" id="accessibility">
       <h2 class="mb-6 text-3xl font-bold font-heading lg:text-5xl">An Accessible Experience</h2>
       <div class="space-y-6 text-xl lg:text-2xl max-w-[60rem]">
         <p>


### PR DESCRIPTION
### addresses issue #61
- modified venue drop down menu to include hrefs for other parts of the venue page like in 2023
- modified venue drop down menu to include href for the room/ride share page
- created room/ride share based on a combination of the visa & hackathon pages